### PR TITLE
Implement static factory inheritance

### DIFF
--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -162,10 +162,7 @@ class ReferencesTestCase(unittest.TestCase):
             origin = factory.SubFactory(OriginFactory)
             target = factory.SubFactory(TargetFactory)
 
-        class OriginWithTargetsFactory(factory_trytond.TrytonFactory):
-            class Meta:
-                model = 'test.many2many'
-
+        class OriginWithTargetsFactory(OriginFactory):
             relation1 = factory.RelatedFactory(
                 RelationFactory,
                 factory_related_name='origin',


### PR DESCRIPTION
While factories declared at runtime -after a trytond
transaction and pool have been setup- could be inherited,
factories declared at module import time couldn't
because of the base factory options assumptions.

Hack the _get_counter_reference method to work with
trytond models.

Also improve the get_model_class so that inherited
classes don't need to repeat the meta model.