### PR TITLE
Use stub attributes to build LazySearch domain

### DIFF
--- a/factory_trytond/__init__.py
+++ b/factory_trytond/__init__.py
@@ -58,10 +58,11 @@ class TrytonFactory(factory.Factory):
         pass
 
 
-class LazySearch(factory.LazyFunction):
-    def __init__(self, model_name, domain, limit=None, *args, **kwargs):
-        def search():
+class LazySearch(factory.LazyAttribute):
+    def __init__(self, model_name, function, limit=None, *args, **kwargs):
+        def search(stub):
             Model = Pool().get(model_name)
+            domain = function(stub)
             records = Model.search(domain, limit=limit)
             return random.choice(records) if records else None
         super(LazySearch, self).__init__(search, *args, **kwargs)

--- a/tests/test_lazy_search.py
+++ b/tests/test_lazy_search.py
@@ -1,0 +1,41 @@
+import unittest
+
+import factory
+
+from trytond.tests.test_tryton import activate_module
+from trytond.tests.test_tryton import with_transaction
+
+import factory_trytond
+
+
+class LazySearchTestCase(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        activate_module('tests')
+
+    @with_transaction()
+    def test_lazy_search(self):
+
+        class ModelFactory(factory_trytond.TrytonFactory):
+            class Meta:
+                model = 'test.model'
+
+        class StubFactory(factory.StubFactory):
+            name = 'foo'
+            foo = factory_trytond.LazySearch(
+                'test.model',
+                lambda stub: [('name', '=', stub.name)],
+            )
+            first = factory_trytond.LazySearch(
+                'test.model',
+                lambda stub: [('name', '=', stub.name)],
+                limit=1,
+            )
+
+        (foo1, foo2) = ModelFactory.create_batch(2, name='foo')
+        bar = ModelFactory.create(name='bar')
+        stubs = StubFactory.build_batch(10)
+
+        self.assertEqual([stub.first for stub in stubs], [foo1] * 10)
+        self.assertNotIn(bar, {stub.foo for stub in stubs})

--- a/tests/test_model_data.py
+++ b/tests/test_model_data.py
@@ -1,0 +1,34 @@
+import unittest
+
+import factory
+
+from trytond.pool import Pool
+from trytond.tests.test_tryton import activate_module
+from trytond.tests.test_tryton import with_transaction
+
+import factory_trytond
+
+
+class ModelDataTestCase(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        activate_module('ir')
+
+    @with_transaction()
+    def test_model_data(self):
+        pool = Pool()
+        Lang = pool.get('ir.lang')
+        Menu = pool.get('ir.ui.menu')
+
+        class StubFactory(factory.StubFactory):
+            english = factory_trytond.ModelData('ir', 'lang_en')
+            admin = factory_trytond.ModelData('ir', 'menu_administration')
+
+        stub = StubFactory.build()
+
+        self.assertIsInstance(stub.english, Lang)
+        self.assertEqual(stub.english.name, 'English')
+
+        self.assertIsInstance(stub.admin, Menu)
+        self.assertEqual(stub.admin.name, 'Administration')


### PR DESCRIPTION
Inherit LazyAttribute instead of LazyFunction so that
the stub (pre-instance representation) is passed
to the search function on evaluation time.

Expect to be declared with a function that will be called
with the stub and must build the trytond search domain.
This is a breaking change!